### PR TITLE
Don't multiply `None` threshold by `threshold_scale`

### DIFF
--- a/pykofamsearch/pykofamsearch.py
+++ b/pykofamsearch/pykofamsearch.py
@@ -21,9 +21,10 @@ def filter_hmmsearch_threshold(
     score_type:str,
     return_failed_threshold:bool,
     ):
+    # If threshold is not None
+    if threshold:
+        threshold = threshold * threshold_scale
     # If there is no score_type value then there is no threshold or profile_type values
-
-    threshold = round(threshold * threshold_scale, 2)
     if not return_failed_threshold:
         if score_type:
             if score_type == "domain":


### PR DESCRIPTION
This fixes the following bug:

```
Traceback (most recent call last):
  File "/clusterfs/jgi/groups/science/homes/apcamargo/.micromamba/bin/pykofamsearch.py", line 244, in <module>
    main(sys.argv[1:])
  File "/clusterfs/jgi/groups/science/homes/apcamargo/.micromamba/bin/pykofamsearch.py", line 187, in main
    result = filter_hmmsearch_threshold(hit, threshold, opts.threshold_scale, score_type, return_failed_threshold=False)
  File "/clusterfs/jgi/groups/science/homes/apcamargo/.micromamba/bin/pykofamsearch.py", line 26, in filter_hmmsearch_threshold
    threshold = round(threshold * threshold_scale, 2)
TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'
```