### PR TITLE
Get missing KOs when using a serialized database

### DIFF
--- a/pykofamsearch/pykofamsearch.py
+++ b/pykofamsearch/pykofamsearch.py
@@ -101,6 +101,7 @@ def main(args=None):
         else:
             f = open(opts.serialized_database, "rb")
         ko_to_data, name_to_hmm = pickle.load(f)
+        missing_kos = ko_to_data.keys() - name_to_hmm.keys()
         f.close()
 
     else:


### PR DESCRIPTION
This PR fixes the following bug:

```
Traceback (most recent call last):
  File "/clusterfs/jgi/groups/science/homes/apcamargo/.micromamba/bin/pykofamsearch.py", line 244, in <module>
    main(sys.argv[1:])
  File "/clusterfs/jgi/groups/science/homes/apcamargo/.micromamba/bin/pykofamsearch.py", line 235, in main
    print("Number of missing KOfams: {}".format(len(missing_kos)), file=sys.stderr)
UnboundLocalError: local variable 'missing_kos' referenced before assignment
```